### PR TITLE
Revert "Update publish.yml"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,8 +36,6 @@ jobs:
       - uses: r7kamura/weneedfeed-action@v3
         with:
           base_url: https://noreyb.github.io/feed-kmn
-      - name: Set permissions for output directory
-        run: chmod 777 output
       - uses: actions/upload-pages-artifact@v1
         with:
           path: output


### PR DESCRIPTION
Reverts noreyb/feed-kmn#12

outputディレクトリの権限がないエラーについての解決策がこれではなかった